### PR TITLE
adding nofollow to keyword links

### DIFF
--- a/pages/services/single.html
+++ b/pages/services/single.html
@@ -111,7 +111,9 @@ eleventyComputed:
       <p class="keywords">
         {%- for keyword in item.Keywords.split(",") %} {%- if
         keyword.trim().length > 0 %}
-        <a href="/services/all/?q={{keyword | trim | urlencode}}+">
+        <a
+          href="/services/all/?q={{keyword | trim | urlencode}}+"
+          rel="nofollow">
           {{- keyword | trim -}} </a
         ><span class="m-r-sm">,</span> {% endif -%} {%- endfor %}
       </p>


### PR DESCRIPTION
- keyword links aren't real links.  Don't need to track "Q=" extra links.