### PR TITLE
solving for legacy redirects (dashline)

### DIFF
--- a/pages/legacyhandler.ashx.njk
+++ b/pages/legacyhandler.ashx.njk
@@ -13,7 +13,13 @@ public class ItemRedirectHandler : IHttpHandler
     // Declare a readonly 2-dimensional array to store the redirects
     private static readonly string[,] redirects = new string[,]
     {
-
+      // Begin Manual entries
+      {"/departments/208/services/1110/", "/service/?item=job-training-in-san-diego"},
+      {"/departments/208/services/1114/", "/service/?item=job-training-in-sacramento"},
+      {"/departments/208/services/1111/", "/service/?item=job-training-in-orange-county"},
+      {"/departments/208/services/1113/", "/service/?item=job-training-in-madera"},
+      {"/departments/208/services/1112/", "/service/?item=job-training-in-long-beach"},
+      // End Manual entries
 
       {%- for agency in state_entity.agencies | sortBy("AgencyId") %}
       {

--- a/pages/legacyhandler.ashx.njk
+++ b/pages/legacyhandler.ashx.njk
@@ -39,6 +39,10 @@ public class ItemRedirectHandler : IHttpHandler
         // Check if both 'item' and 'path' parameters are present
         if (!string.IsNullOrEmpty(item) && !string.IsNullOrEmpty(path))
         {
+            // Replace "dashline" with "-" in the 'item' string
+            // Some old indexes have this
+            item = item.Replace("dashline", "-");
+
             // Construct the legacy path using the 'item' and 'path' parameters
             string legacyPath = String.Format("/{0}/?item={1}", path, item);
             string targetPath = null;


### PR DESCRIPTION
Should fix these redirects...
https://www.ca.gov/agency/?item=highdashlinespeed-rail-authority
https://www.ca.gov/agency/?item=infrastructure-and-economic-development-bank-(idashlinebank)
https://www.ca.gov/agency/?item=sacramentodashlinesan-joaquin-delta-conservancy
https://www.ca.gov/agency/?item=speechdashlinelanguage-pathology-and-audiology-and-hearing-aid-dispensers-board
https://www.ca.gov/service/?item=apply-for-compensation-for-crimedashlinerelated-expenses
https://www.ca.gov/service/?item=apply-for-medidashlinecal
https://www.ca.gov/service/?item=ca-coviddashline19-rent-relief
https://www.ca.gov/service/?item=calfile-dashline-file-return-for-free
https://www.ca.gov/service/?item=find-edashlinebenefits-in-your-county
https://www.ca.gov/service/?item=get-coviddashline19-information-and-help
https://www.ca.gov/service/?item=learn-about-jobs-for-foreigndashlineborn-professionals
https://www.ca.gov/service/?item=learn-more-about-medidashlinecal-for-daca


AND these manual ones
https://www.ca.gov/service/?item=job-training-in-san-diego
https://www.ca.gov/service/?item=job-training-in-sacramento https://www.ca.gov/service/?item=job-training-in-orange-county
https://www.ca.gov/service/?item=job-training-in-madera
https://www.ca.gov/service/?item=job-training-in-long-beach
