### PR TITLE
sitemap lastmod

### DIFF
--- a/pages/sitemap.xml.njk
+++ b/pages/sitemap.xml.njk
@@ -8,6 +8,7 @@ eleventyExcludeFromCollections: true
   {%- for page in collections.all %}
   <url>
     <loc>{{-site.url-}}{{-page.url-}}</loc>
+    <lastmod>{{-page.date.toISOString()-}}</lastmod>
   </url>
   {%- endfor %}
 </urlset>


### PR DESCRIPTION
- Putting lastmod back in sitemap
- Will help prioritize search traffic and prevent repeat crawls since all content is updated togther