### PR TITLE
fixing keyword list, alpha, lcase links

### DIFF
--- a/pages/services/single.html
+++ b/pages/services/single.html
@@ -111,10 +111,10 @@ eleventyComputed:
       {%- endif -%}
       <h3>Keywords</h3>
       <p class="keywords">
-        {%- for keyword in item.Keywords.split(",") %} {%- if
+        {%- for keyword in item.Keywords.split(",") | sort %} {%- if
         keyword.trim().length > 0 %}
         <a
-          href="/services/all/?q={{keyword | trim | urlencode}}+"
+          href="/services/all/?q={{keyword | trim | lower | urlencode}}+"
           rel="nofollow">
           {{- keyword | trim -}} </a
         ><span class="m-r-sm">,</span> {% endif -%} {%- endfor %}


### PR DESCRIPTION
keyword list
- alphabetize (ignoring case)
- lower case for links, to detect duplicate links better