### PR TITLE
case insensitive matching for "pluck"

### DIFF
--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -57,11 +57,17 @@ module.exports = function (
 
         switch (operator?.toLowerCase()) {
           case "includes":
-            return itemval.includes(value);
+            return itemval
+              .toString()
+              .toLowerCase()
+              .includes(value.toString().toLowerCase());
           case "not":
             return itemval !== value;
           case "startswith":
-            return itemval.startsWith(value);
+            return itemval
+              .toString()
+              .toLowerCase()
+              .startsWith(value.toString().toLowerCase());
           default:
             return itemval === value;
         }


### PR DESCRIPTION
Fixes the service count being off because of...

"eVQ - Electronic Verification Questionnaire"

(Lowercase in the title)