### PR TITLE
HTML5 hidden for lists

### DIFF
--- a/src/js/index.mjs
+++ b/src/js/index.mjs
@@ -171,6 +171,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
             rowElement.style.display = bShow ? "" : "none";
             rowElement.ariaHidden = bShow ? null : "true";
+            rowElement.hidden = !bShow;
           });
         };
         if (inputBox) inputBox.addEventListener("input", checkme);


### PR DESCRIPTION
- adding HTML5 hidden for better siteimprove crawling
- less false positives for search lists.