### PR TITLE
FAQ ID sort

### DIFF
--- a/src/_data/state_entity.cjs
+++ b/src/_data/state_entity.cjs
@@ -58,6 +58,8 @@ module.exports = async function () {
     qa: /** @type {*[]} */ (returns[2])
   };
 
+  results.qa.sort((a, b) => a.Id - b.Id);
+
   results.agencies.forEach(item => {
     trimObjectProperties(item);
 


### PR DESCRIPTION
Sorts based on database ID instead of alpha for FAQs.

As seen as a problem here...
https://www.ca.gov/departments/219/services/1129/