### PR TITLE
removing google tag manager as preconnect.

### DIFF
--- a/src/_includes/head-js-css.html
+++ b/src/_includes/head-js-css.html
@@ -1,7 +1,6 @@
 <!-- Public Sans Font-->
 <link rel="preconnect" href="https://cdn.cdt.ca.gov" crossorigin="anonymous" />
 <link rel="preconnect" href="https://fonts.gstatic.com" />
-<link rel="preconnect" href="https://www.googletagmanager.com" />
 <!-- End Public Sans Font -->
 
 <!-- State Web template required CSS -->


### PR DESCRIPTION
It's an async request anyway, does not need to be a priority connect.

Lighthouse pointed out overusing preconnects. > 2