### PR TITLE
678 get help online replace docs link

### DIFF
--- a/pages/initiatives/lafires/get-help-online.html
+++ b/pages/initiatives/lafires/get-help-online.html
@@ -178,7 +178,9 @@ keywords: LA, Los Angeles, fires, wildfires
         </div>
       </div>
 
-      <h2 class="m-b-0">Replacing your personal documents</h2>
+      <h2 id="Replacing-your-personal-documents" class="m-b-0">
+        Replacing your personal documents
+      </h2>
 
       <div class="row">
         <div class="col-lg-6 m-t-md">

--- a/pages/initiatives/lafires/index.html
+++ b/pages/initiatives/lafires/index.html
@@ -21,11 +21,19 @@ keywords: LA, Los Angeles, fires, wildfires
       <h1 class="m-t-0 h2">{{title}}</h1>
       <p>Help and info for people affected by the wildfires</p>
 
-      <a
-        href="/lafires/get-help-in-person/"
-        class="btn btn-outline-primary btn-lg bg-gray-75-hover m-t m-r"
-        >Get help in person
-      </a>
+      <div class="btn-row d-flex gap-2 m-t-lg">
+        <a
+          href="/lafires/get-help-in-person/"
+          class="btn btn-outline-primary btn-sm bg-gray-75-hover m-t m-r p-a-sm"
+          >Get help in person
+        </a>
+
+        <a
+          href="/lafires/get-help-online/"
+          class="btn btn-outline-primary btn-sm bg-gray-75-hover m-t m-r p-a-sm"
+          >Get help online
+        </a>
+      </div>
     </div>
     <div
       class="col-lg-8 bg-s3"

--- a/pages/initiatives/lafires/index.html
+++ b/pages/initiatives/lafires/index.html
@@ -21,19 +21,11 @@ keywords: LA, Los Angeles, fires, wildfires
       <h1 class="m-t-0 h2">{{title}}</h1>
       <p>Help and info for people affected by the wildfires</p>
 
-      <div class="btn-row d-flex gap-2 m-t-lg">
-        <a
-          href="/lafires/get-help-in-person/"
-          class="btn btn-outline-primary btn-sm bg-gray-75-hover m-t m-r p-a-sm"
-          >Get help in person
-        </a>
-
-        <a
-          href="/lafires/get-help-online/"
-          class="btn btn-outline-primary btn-sm bg-gray-75-hover m-t m-r p-a-sm"
-          >Get help online
-        </a>
-      </div>
+      <a
+        href="/lafires/get-help-in-person/"
+        class="btn btn-outline-primary btn-lg bg-gray-75-hover m-t m-r"
+        >Get help in person
+      </a>
     </div>
     <div
       class="col-lg-8 bg-s3"

--- a/pages/initiatives/lafires/index.html
+++ b/pages/initiatives/lafires/index.html
@@ -23,15 +23,15 @@ keywords: LA, Los Angeles, fires, wildfires
 
       <div class="btn-row d-flex gap-2 m-t-lg">
         <a
-          href="/lafires/get-help-in-person/"
-          class="btn btn-outline-primary btn-sm bg-gray-75-hover m-t m-r p-a-sm"
-          >Get help in person
-        </a>
-
-        <a
           href="/lafires/get-help-online/"
           class="btn btn-outline-primary btn-sm bg-gray-75-hover m-t m-r p-a-sm"
           >Get help online
+        </a>
+
+        <a
+          href="/lafires/get-help-in-person/"
+          class="btn btn-outline-primary btn-sm bg-gray-75-hover m-t m-r p-a-sm"
+          >Get help in person
         </a>
       </div>
     </div>
@@ -70,6 +70,27 @@ keywords: LA, Los Angeles, fires, wildfires
           class="link-grid bg-white bg-gray-50-hover no-icon"
           ><h3 class="m-a-0 font-size-20 bold">Return home safely</h3></a
         >
+      </div>
+
+      <div class="p-a-md m-t-sm m-b-md d-flex align-items-top p-t-lg">
+        <div>
+          <span
+            class="ca-gov-icon-info-line m-r color-p2-darker"
+            aria-hidden="true"></span>
+        </div>
+        <div>
+          <p class="color-p2-darker m-b-0">
+            <strong>Deadline for free debris removal: March 31, 2025</strong
+            ><br />
+
+            Learn how to get free debris removal.
+            <a href="https://recovery.lacounty.gov/debris-removal/"
+              >Debris removal - LA County Recovers<span
+                class="external-link-icon"
+                aria-hidden="true"></span
+            ></a>
+          </p>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Issue:
The in-page navigation link (`#Replacing-your-personal-documents`) was not working because the target <h2> heading did not have an id attribute. Clicking the link would only navigate to the page but not scroll to the intended section.
![image](https://github.com/user-attachments/assets/a30254ec-9b6c-40f0-9fd0-5e80a64b196d)

Need to go here on click:
![image](https://github.com/user-attachments/assets/f744dd4f-7080-4cd0-937d-a44cf1fc09d1)


Solution:
Added` id="Replacing-your-personal-documents"` to the `<h2>` element, ensuring the anchor link correctly jumps to the section.

Result:
Users can now click the link and be taken directly to the 'Replacing your personal documents' section on the page as expected.