### PR TITLE
Remove Pasadena

### DIFF
--- a/pages/initiatives/lafires/index.html
+++ b/pages/initiatives/lafires/index.html
@@ -126,8 +126,8 @@ keywords: LA, Los Angeles, fires, wildfires
           >
         </h3>
         <p class="m-b text-left">
-          Disaster Recovery Centers are open in Altadena, Pasadena, and UCLA
-          Research Park West.
+          Disaster Recovery Centers are open in Altadena and UCLA Research Park
+          West.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Removed Pasadena as one of the options on the LA fires homepage > What you can do section

Before:
![{3DB69B39-1043-487C-ADEA-867920621563}](https://github.com/user-attachments/assets/ccdbe906-9593-4e24-b413-2ca2642c13c1)

After:
![{08D9F6E3-FA5A-4CA4-A944-A532EF91316F}](https://github.com/user-attachments/assets/f6a6c61b-2a41-44b0-bd8a-78e782a99f69)
