### PR TITLE
Map a11y patches #3

### DIFF
--- a/pages/initiatives/lafires/get-help-in-person.html
+++ b/pages/initiatives/lafires/get-help-in-person.html
@@ -154,6 +154,9 @@ lafires_header: true
   .leaflet-tooltip {
     font-weight: 700;
     color: #207AC9 !important;
+  } 
+  .skip-map {
+    margin-bottom: 1rem;
   }
 </style>
 
@@ -189,7 +192,7 @@ lafires_header: true
       <nav class="page-navigation m-t-lg"></nav>
 
       <h2 class="mt-4">Find the nearest Disaster Recovery Center</h2>
-      <a class="sr-only skip-map" href="#recovery-center-cards">(skip map)</a>
+      <a class="skip-map btn btn-primary rounded-5" href="#recovery-center-cards">Skip map</a>
 
       <div class="cagov-map-and-tiles">
         <cagov-lafires-map></cagov-lafires-map>

--- a/src/js/map-feature.mjs
+++ b/src/js/map-feature.mjs
@@ -2,6 +2,7 @@ let displayData = [
   {'lat':34.0395943,'lng':-118.4314774, 
     'drc_name':'UCLA Disaster Recovery Center', 
     'loc_name':'UCLA Research Park West', 
+    'id':'drc-ucla',
     'loc_address':'10850 West Pico Blvd., Los Angeles, CA 90064', 
     'tooltip':'UCLA Disaster Recovery Center', 
     'tooltip_dir':'bottom',
@@ -18,6 +19,7 @@ let displayData = [
   {'lat':34.1825977,'lng':-118.1646802, 
     'drc_name': 'Altadena Disaster Recovery Center', 
     'loc_name':'', 
+    'id':'drc-altadena',
     'loc_address':'540 W. Woodbury Rd., Altadena, CA 91001', 
     'tooltip':'Altadena Disaster Recovery Center', 
     'tooltip_dir':'bottom', 
@@ -178,6 +180,13 @@ export class CaGovLAFiresMap extends window.HTMLElement {
         this.closePopup();
       }
     });
+
+    // find first element in map with class leaflet-control-zoom-in and assign it the id of leaflet-control-zoom-in
+    let zoomIn = this.getElementsByClassName('leaflet-control-zoom-in')[0];
+    zoomIn.id = 'leaflet-control-zoom-in';
+
+    let zoomOut = this.getElementsByClassName('leaflet-control-zoom-out')[0];
+    zoomOut.id = 'leaflet-control-zoom-out';
 
     window.L.tileLayer(tile_template.replace("{r}", ""), {
       // retina tiles
@@ -371,7 +380,8 @@ export class CaGovLAFiresMap extends window.HTMLElement {
       if (cal_bounds.contains(latlng)) {
         let marker = L.marker([item.lat, item.lng],{icon:this.regIcon, keyboard:true,riseOnHover:true,highlight: 'temporary',alt:item.drc_name}).addTo(this.map);
         // marker.bindTooltip(item.tooltip || item.drc_name, {permanent: true, direction: item.tooltip_dir, interactive: true, offset: item.tooltip_offset}).openTooltip();
-
+        marker._icon.id = item.id;
+        marker._icon.setAttribute('aria-live', 'polite');
         let clickFunc = e => {
           // console.log("Marker click",e);
           e.originalEvent.stopPropagation();


### PR DESCRIPTION
* Makes skip map a visible button, rather than only visible to screen readers.
* Adds aria-live="polite" to map pins.

NOTE: There was a request from Linda to change the tab order order of the map.  This is a known issue with Leaflet and difficult for me to fix.

A several-years-old discussion on the issue can be viewed here.  https://github.com/Leaflet/Leaflet/issues/7479
