### PR TITLE
update stay healthy link to dedicated new page

### DIFF
--- a/pages/initiatives/lafires/index.html
+++ b/pages/initiatives/lafires/index.html
@@ -63,7 +63,7 @@ lafires_header: true
     <div class="row">
       <div class="col-lg-4 m-t-md">
         <a
-          href="/lafires/get-help-online/#Staying-healthy"
+          href="/lafires/stay-healthy/"
           class="link-grid bg-white bg-gray-50-hover no-icon"
           ><h3 class="m-a-0 font-size-20 bold">Stay healthy</h3></a
         >


### PR DESCRIPTION
Fix for #1061 

Replaces homepage Stay healthy link (Top needs section) with new dedicated page at /lafires/stay-healthy/

![{22455709-D1DC-41D3-AE91-1B1BE9A9A6AD}](https://github.com/user-attachments/assets/e0f4edc0-721c-46eb-992d-31b1a3413c61)
