### PR TITLE
robots crawl cleanup

### DIFF
--- a/src/root/robots-prod.txt
+++ b/src/root/robots-prod.txt
@@ -1,8 +1,16 @@
 User-agent: *
 Allow: /
+
+# Recommended for all sites
 Disallow: /ads.txt
 Disallow: /app-ads.txt
 Disallow: /.well-known/assetlinks.json
 Disallow: /.well-known/apple-app-site-association
+Disallow: /apple-app-site-association
+
+# www.ca.gov specificly, reduces 404 crawl attempts
+Disallow: /serp
+Disallow: /state/portal/
+Disallow: /state/govsite/
 
 Sitemap: https://www.ca.gov/sitemaps/sitemapindex.xml


### PR DESCRIPTION
Reducing the 404 crawl attempts found here...

https://search.google.com/search-console/settings/crawl-stats/drilldown?resource_id=https%3A%2F%2Fwww.ca.gov%2F&response=2&hl=en

most are to the old "serp" page, which we don't have anymore, but Chinese hackers are trying (And effectively) wasting crawl budget here. 

also plenty of crawls to an old (old?) "myca" jsp service in the "/state/" folder.