### PR TITLE
DEV - SEO - removing dots after domain

### DIFF
--- a/src/root/web.config
+++ b/src/root/web.config
@@ -119,6 +119,14 @@
           <action type="Redirect" url="/lafires/docs/{R:1}{R:2}" appendQueryString="true" redirectType="Permanent" />
         </rule>
         <!-- End LA fires custom redirects -->
+
+        <rule name="Normalize trailing dot domains (e.g., www.ca.gov.)" stopProcessing="true">
+          <match url=".*" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="\.$" />
+          </conditions>
+          <action type="Redirect" url="https://{HTTP_HOST:TrimEnd('.')}/{R:1}" redirectType="Permanent" />
+        </rule>
       </rules>
       <outboundRules>
         <rule name="Add Strict-Transport-Security when HTTPS">


### PR DESCRIPTION
redirect when using dot after domain to consolodate analytics.
https://www.ca.gov./
vs
https://www.ca.gov/