### PR TITLE
Improved querystring whitelist for any page (helps analytics)

### DIFF
--- a/pages/404.html
+++ b/pages/404.html
@@ -5,6 +5,7 @@ permalink: "404.html"
 description: "We're sorry, that link didn't work."
 noindex: true
 eleventyExcludeFromCollections: true
+allowedQueryParams: "*"
 ---
 
 <div class="row">

--- a/pages/410.html
+++ b/pages/410.html
@@ -5,6 +5,7 @@ permalink: "410.html"
 description: "We're sorry, that page has been permanently removed."
 noindex: true
 eleventyExcludeFromCollections: true
+allowedQueryParams: "*"
 ---
 
 <div class="row">

--- a/pages/index.html
+++ b/pages/index.html
@@ -7,6 +7,7 @@ layout: landing
 category1: Press releases
 category2: Top story
 category3: Public safety
+allowedQueryParams: utm_campaign,utm_medium,utm_source
 ---
 
 <style>

--- a/pages/search/index.html
+++ b/pages/search/index.html
@@ -6,6 +6,7 @@ layout: landing
 noindex: true
 hide_search: true
 eleventyExcludeFromCollections: true
+allowedQueryParams: q
 ---
 
 <div

--- a/pages/services/all.html
+++ b/pages/services/all.html
@@ -7,6 +7,7 @@ dynamic_sidenavid: service
 side_filter_data: services
 noindex_follow: true
 data_service: true
+allowedQueryParams: q
 ---
 
 <div

--- a/src/_includes/head-js-css.html
+++ b/src/_includes/head-js-css.html
@@ -15,7 +15,7 @@
   integrity="sha256-MRHAOqwc4jjHeTGa/9mcdxAv3aVG+lQ7eJ9DPa+Gr/k="
   crossorigin="anonymous"
   defer></script>
-<script src="/js/custom.min.js?vJuly2025" type="module" defer></script>
+<script src="/js/custom.min.js?vJuly2025a" type="module" defer></script>
 {%- if data_agency %}
 <script src="/js/data_agency.min.js?dv{% DateHex %}"></script>
 {% endif -%} {%- if data_service %}

--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -23,6 +23,8 @@
     <meta name="title" content="{% metatitle %}" />
     {%- if updated %}
     <meta name="last-modified" content="{{ updated }}" />
+    {%- endif -%} {#- Allowed query parameters -#} {%- if allowedQueryParams %}
+    <meta name="allowed-query-params" content="{{ allowedQueryParams }}" />
     {%- endif %}
 
     <!-- Canonical link, improves SEO -->

--- a/src/js/index.mjs
+++ b/src/js/index.mjs
@@ -231,9 +231,10 @@ Fix URLS for analytics and SEO
   }
 
   // 2. Process query parameters based on meta tag
-  /** @type {HTMLMetaElement | null} */
-  const metaTag = document.querySelector('meta[name="allowed-query-params"]');
-  const metaTagContent = metaTag?.content.trim();
+  const metaTagContent = /** @type {HTMLMetaElement | null} */ (
+    document.querySelector('meta[name="allowed-query-params"]')
+  )?.content.trim();
+
   if (!metaTagContent) {
     // No meta tag found, remove all query parameters
     url.search = "";

--- a/src/js/index.mjs
+++ b/src/js/index.mjs
@@ -214,7 +214,7 @@ window.addEventListener("DOMContentLoaded", () => {
 })();
 
 /* -----------------------------------------
-Fix URLS for search results
+Fix URLS for analytics and SEO
 ----------------------------------------- */
 (() => {
   const rawUrl = window.location.href;
@@ -230,34 +230,29 @@ Fix URLS for search results
     return; // Stop further processing after redirecting
   }
 
-  // 2. Read meta tag to determine allowed query params
-  let allowAllParams = false;
-  let allowedKeys = [];
+  // 2. Process query parameters based on meta tag
   /** @type {HTMLMetaElement | null} */
   const metaTag = document.querySelector('meta[name="allowed-query-params"]');
+  const metaTagContent = metaTag?.content.trim();
+  if (!metaTagContent) {
+    // No meta tag found, remove all query parameters
+    url.search = "";
+  } else if (metaTagContent !== "*") {
+    // non-wildcard content, filter query parameters
+    const allowedKeys = metaTagContent
+      .split(",")
+      .map(k => k.trim())
+      .filter(Boolean);
 
-  if (metaTag?.content.trim()) {
-    const content = metaTag.content.trim();
-    if (content === "*") {
-      allowAllParams = true;
-    } else {
-      allowedKeys = content
-        .split(",")
-        .map(k => k.trim())
-        .filter(Boolean);
-    }
-  }
+    const params = new URLSearchParams(url.search);
 
-  // 3. Sanitize query string
-  const params = new URLSearchParams(url.search);
-  if (!allowAllParams) {
     for (const key of [...params.keys()])
       if (!allowedKeys.includes(key)) params.delete(key);
+
+    url.search = params.toString();
   }
 
-  url.search = params.toString();
-
-  // 4. Replace URL if modified
+  // 3. Replace URL if modified
   if (rawUrl !== url.toString()) {
     console.log("URL modified:", {
       original: rawUrl,


### PR DESCRIPTION
- Each page can now have a meta tag with comma separated values (or "*")  to whitelist querystrings.
- Replaces logic that had page names hardcoded in JS