### PR TITLE
Add disaster recovery page

### DIFF
--- a/pages/topics/disaster-recovery.html
+++ b/pages/topics/disaster-recovery.html
@@ -1,0 +1,459 @@
+---
+description: Steps Californians can take to be ready for disaster, and to recover if one happens.
+title: Disaster recovery
+landing: Services
+dynamic_sidenavid: topic
+layout: landing
+breadcrumbparent: Topics
+keywords: 
+  - disaster recovery
+  - wildfire 
+  - flood 
+  - earthquake 
+  - landslide
+  - tsunami
+---
+<style>
+  .disaster-recovery-page {
+    --disaster-icon-fill: #5A596B;
+  }
+
+  .disaster-alerts {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    padding: 1.25rem;
+    margin-block: 1rem 4rem;
+    border-radius: 0.3125rem;
+    border-left: 0.5rem solid #FFA726;
+    background: #FFF3E0;
+
+    & > p { 
+      margin: 0;
+      line-height: normal;
+    }
+  }
+
+  .accordion-group {
+    margin-block-end: 5rem;
+
+    & summary {
+      padding-inline: 1rem 3.75rem;
+      display: flex;
+      align-items: center;
+      gap: .75rem;
+
+      &::before {
+        left: unset;
+        right: 0;
+        border-right: none;
+        border-left: 1px solid var(--gray-200,#d4d4d7);
+      }
+    }
+    & svg {
+      flex: 0 0 1.5rem;
+    }
+    & .cagov-open-indicator {
+      left: unset;
+      right: 2.15rem;
+
+      &::before {
+        transform: rotate(90deg);
+      }
+    }
+
+    & details[open] .cagov-open-indicator::before {
+      transform: rotate(270deg) translateY(0) translateX(-0.1rem) !important;
+    }
+  }
+
+  .recovery-card-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(336px, 1fr));
+    gap: 1.5rem;
+    margin-block-end: 5rem;
+  }
+
+  .recovery-card-group-safety {
+    --recovery-card-background-color: #F0F4F0;
+  }
+
+  .recovery-card-group-food-shelter {
+    --recovery-card-background-color: #FDF2E9;
+  }
+
+  .recovery-card-group-health {
+    --recovery-card-background-color: #F0F6FA;
+  }
+
+  .recovery-card-group-documents {
+    --recovery-card-background-color: #F5F3F7;
+  }
+
+  .recovery-card-group-financial {
+    --recovery-card-background-color: #FAF7F2;
+  }
+
+  .recovery-card {
+    background-color: var(--recovery-card-background-color);
+    padding: 2.25rem 1.75rem;
+    border-radius: 1.5rem;
+    display: grid;
+    grid-template-columns: 1.75rem 1fr;
+    grid-template-rows: min-content auto;
+    gap: 1.25rem .75rem;
+
+    & > *:nth-child(n+3) {
+      grid-column-start: 2;
+      align-self: start;
+    }
+
+    & > svg {
+      max-width: 1.75rem;
+      max-height: 2rem;
+      height: 100%;
+      width: auto;
+      align-self: start;
+    }
+
+    & > h3 {
+      line-height: 133.3%;
+      font-size: 1.5rem;
+      margin: 0;
+      align-self: center;
+    }
+
+    & .external-link-icon {
+      display: none;
+    }
+
+    & ul {
+      padding: 0;
+      margin: 0;
+    }
+
+    & li {
+      list-style-type: none;
+      padding-block: 1rem;
+      border-bottom: 1px solid #D4D4D7;
+
+      &:first-child {
+        border-top: 1px solid #D4D4D7;
+      }
+    }
+
+    & a {
+      text-decoration: none !important;
+      inline-size: 100%;
+      display: flex;
+      gap: .5rem;
+      align-items: center;
+      justify-content: space-between;
+
+      &::after {
+        content: '';
+        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="7" height="13" viewBox="0 0 7 13" fill="none"><path d="M0.219375 11.898C0.512375 12.191 0.987375 12.191 1.27937 11.898L6.14337 7.03295C6.29037 6.88595 6.36437 6.69195 6.36237 6.49995C6.36237 6.30595 6.29037 6.11395 6.14337 5.96695L1.27937 1.10195C0.986375 0.808952 0.511375 0.808952 0.219375 1.10195C-0.0726248 1.39495 -0.0736248 1.86995 0.219375 2.16295L4.55638 6.49995L0.220375 10.837C-0.0726254 11.13 -0.0726254 11.605 0.220375 11.898H0.219375Z" fill="%233B3A48"/></svg>');
+        width: 0.39763rem;
+        height: 0.70219rem;
+        flex-shrink: 0;
+        background-size: cover;
+        display: block;
+        margin-inline: 1rem;
+      }
+
+      &:hover {
+        text-decoration: underline !important;
+      }
+    }
+  }
+</style>
+
+<div class="section-understated lineart bg-s1">
+  <div class="container p-y-md">
+    {%- include "breadcrumbs.html" -%}
+    <h1 class="m-t-0 color-p2-darker">{{title}}</h1>
+  </div>
+</div>
+
+<div class="container p-y-lg disaster-recovery-page">
+  <div class="row p-b-lg">
+    <div class="col-lg-3 pb-lg-5" role="complementary">
+      <!-- Side navigation -->
+      <nav class="side-navigation sticky-6">
+        <a href="javascript:;" aria-hidden="true" class="d-none">{{title}}</a>
+        <ul class="list-navigation">
+          <li>
+            <a href="/topics/" class="landing back" id="color-themes-list"
+              ><span class="sr-only">Back to </span>
+              Topics
+            </a>
+          </li>
+
+          {# Hack an additional item into the sidebar nav. #}
+          {%- set disasterRecoveryObj = { featureOrder: 8.5, slug: "disaster-recovery", name: "Disaster recovery" } -%}
+          {%- set modifiedTopics = topics.concat(disasterRecoveryObj) -%}
+
+          {%- for link in modifiedTopics | sortBy("featureOrder") %} {%- set href =
+          "/topics/"+link.slug+"/" -%} {%- set active = href === page.url -%}
+          <li>
+            <a
+              href="{{-href-}}"
+              {%-if
+              active%}
+              class="active landing"
+              aria-current="page"
+              tabindex="-1"
+              {%-endif-%}>
+              {{-link.text | default(link.name) | safe-}}
+            </a>
+          </li>
+          {%- endfor %}
+        </ul>
+      </nav>
+    </div>
+    <div class="col-lg-9 mx-auto">
+      <div class="disaster-alerts">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="31" viewBox="0 0 24 31" fill="none">
+          <path d="M21.7199 13.8493C21.3257 13.3426 20.8458 12.9035 20.4001 12.4644C19.2518 11.451 17.9492 10.7248 16.8522 9.66072C14.2984 7.19487 13.7328 3.12453 15.3611 0C13.7328 0.388456 12.3102 1.2667 11.0933 2.2294C6.65408 5.74239 4.90583 11.9408 6.99687 17.2609C7.06543 17.4298 7.13399 17.5987 7.13399 17.8183C7.13399 18.1899 6.87689 18.5276 6.5341 18.6628C6.13989 18.8316 5.72853 18.7303 5.40288 18.4601C5.30004 18.3756 5.23148 18.2912 5.16292 18.173C3.22614 15.7578 2.91762 12.2955 4.22024 9.52561C1.35791 11.8226 -0.201809 15.7071 0.0210077 19.3721C0.123846 20.2166 0.226684 21.061 0.51806 21.9055C0.758016 22.9189 1.22079 23.9322 1.73498 24.8274C3.58607 27.7492 6.7912 29.8435 10.2363 30.2658C13.9042 30.7218 17.8292 30.0631 20.6401 27.5635C23.7767 24.7598 24.8736 20.2672 23.2625 16.4165L23.0396 15.9773C22.6797 15.2004 21.7199 13.8493 21.7199 13.8493ZM16.3037 24.4896C15.8238 24.8949 15.0354 25.3341 14.4184 25.503C12.4987 26.1785 10.5791 25.2327 9.44785 24.118C11.4875 23.6451 12.7044 22.1589 13.0643 20.6557C13.3557 19.3046 12.8072 18.1899 12.5844 16.8894C12.3787 15.6396 12.413 14.5755 12.8758 13.4102C13.2015 14.052 13.5442 14.6938 13.9556 15.2004C15.2754 16.8894 17.3493 17.6325 17.7949 19.9295C17.8635 20.1659 17.8977 20.4024 17.8977 20.6557C17.9492 22.0406 17.3321 23.5607 16.3037 24.4896Z" fill="#5A596B"/>
+        </svg>
+        <p>See ongoing support for survivors of the <a href="/LAfires/">LA Fires</a>.</p>
+      </div>
+
+      <h2 class="m-b-md">When disaster strikes</h2>
+      <p class="m-b-md">Wildfires, earthquakes, floods — every disaster is different. These are suggestions for what to do first.</p>
+      <div class="accordion-group">
+        <cagov-accordion>
+          <details>
+            <summary>
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="30" viewBox="0 0 24 30" fill="none">
+                <path d="M0 25.5V22.5H3V12C3 9.925 3.625 8.08125 4.875 6.46875C6.125 4.85625 7.75 3.8 9.75 3.3V0H14.25V3.3C16.25 3.8 17.875 4.85625 19.125 6.46875C20.375 8.08125 21 9.925 21 12V22.5H24V25.5H0ZM12 30C11.175 30 10.4688 29.7062 9.88125 29.1187C9.29375 28.5312 9 27.825 9 27H15C15 27.825 14.7063 28.5312 14.1188 29.1187C13.5313 29.7062 12.825 30 12 30ZM10.5 16.5H13.5V9H10.5V16.5ZM12 21C12.425 21 12.7812 20.8562 13.0688 20.5687C13.3563 20.2812 13.5 19.925 13.5 19.5C13.5 19.075 13.3563 18.7188 13.0688 18.4312C12.7812 18.1438 12.425 18 12 18C11.575 18 11.2188 18.1438 10.9313 18.4312C10.6438 18.7188 10.5 19.075 10.5 19.5C10.5 19.925 10.6438 20.2812 10.9313 20.5687C11.2188 20.8562 11.575 21 12 21Z" fill="#5A596B"/>
+              </svg>
+              Heed any alerts
+            </summary>
+            <div class="accordion-body">
+              <p>
+                <a href="https://www.listoscalifornia.org/alerts/">Emergency alerts</a> will tell you how to stay safe. If you have a disability or access needs, evacuate early—getting help takes time.
+              </p>
+            </div>
+          </details>
+        </cagov-accordion>
+        <cagov-accordion>
+          <details>
+            <summary>
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="27" viewBox="0 0 24 27" fill="none">
+                <path d="M12 0L0 9V27H24V9L12 0ZM8.625 14.25C9.66 14.25 10.5 15.09 10.5 16.125C10.5 17.16 9.66 18 8.625 18C7.59 18 6.75 17.16 6.75 16.125C6.75 15.09 7.59 14.25 8.625 14.25ZM19.5 22.5H18V20.25H6V22.5H4.5V12H6V18.75H11.25V13.5H16.5C18.15 13.5 19.5 14.85 19.5 16.5V22.5Z" fill="#5A596B"/>
+              </svg>
+              Seek shelter
+            </summary>
+            <div class="accordion-body">
+              <p>Call 211 and check news reports for emergency shelters in your area.</p>
+            </div>
+          </details>
+        </cagov-accordion>
+        <cagov-accordion>
+          <details>
+            <summary>
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="27" viewBox="0 0 24 27" fill="none">
+                <path d="M12 0L0 9V27H24V9L12 0ZM12.75 14.25C12.75 15.495 11.745 16.5 10.5 16.5V22.5H9V16.5C7.755 16.5 6.75 15.495 6.75 14.25V9.75H8.25V14.25H9V9.75H10.5V14.25H11.25V9.75H12.75V14.25ZM16.5 22.5H15V17.25H13.5V12.75C13.5 11.1 14.85 9.75 16.5 9.75V22.5Z" fill="#5A596B"/>
+              </svg>
+              Find food
+            </summary>
+            <div class="accordion-body">
+              <p>Look for an emergency shelter or local <a href="https://cdss.ca.gov/food-banks">food bank</a>.</p>
+            </div>
+          </details>
+        </cagov-accordion>
+
+        <cagov-accordion>
+          <details>
+            <summary>
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+                <path d="M0 21V3H24V21H0ZM9 14C9.83333 14 10.5417 13.7083 11.125 13.125C11.7083 12.5417 12 11.8333 12 11C12 10.1667 11.7083 9.45833 11.125 8.875C10.5417 8.29167 9.83333 8 9 8C8.16667 8 7.45833 8.29167 6.875 8.875C6.29167 9.45833 6 10.1667 6 11C6 11.8333 6.29167 12.5417 6.875 13.125C7.45833 13.7083 8.16667 14 9 14ZM2.1 19H15.9C15.2 17.75 14.2333 16.7708 13 16.0625C11.7667 15.3542 10.4333 15 9 15C7.56667 15 6.23333 15.3542 5 16.0625C3.76667 16.7708 2.8 17.75 2.1 19ZM17.25 12H18.75V10.3L20.225 11.15L20.975 9.85L19.5 9L20.975 8.15L20.225 6.85L18.75 7.7V6H17.25V7.7L15.775 6.85L15.025 8.15L16.5 9L15.025 9.85L15.775 11.15L17.25 10.3V12Z" fill="#5A596B"/>
+              </svg>
+              Contact a disaster relief service
+            </summary>
+            <div class="accordion-body">
+              <p>Call 211, or contact your local emergency services or the <a href="https://www.redcross.org/find-your-local-chapter.html">Red Cross</a>. In a state of emergency, your area may get a disaster center. This center can help you with all the steps on this page. </p>
+            </div>
+          </details>
+        </cagov-accordion>
+
+        <cagov-accordion>
+          <details>
+            <summary>
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+                <g clip-path="url(#clip0_277_5556)">
+                  <path d="M16.1809 24L11.5666 19.325L13.0956 17.7575L16.1809 20.865L22.3788 14.65L23.9078 16.2175L16.1809 24ZM4.24915 21.8V11.4875L2.28328 13L1 11.2675L12.9863 2L25 11.24L23.6894 13L22.0785 11.79L16.1809 17.7575L13.0956 14.65L8.42662 19.38L10.802 21.8H4.24915Z" fill="#5A596B"/>
+                </g>
+                <defs>
+                  <clipPath id="clip0_277_5556">
+                    <rect width="24" height="24" fill="white"/>
+                  </clipPath>
+                </defs>
+              </svg>
+              Find out if your area is safe to re-enter
+            </summary>
+            <div class="accordion-body">
+              <p>Local officials should announce when you can return to your area.</p>
+            </div>
+          </details>
+        </cagov-accordion>
+
+        <cagov-accordion>
+          <details>
+            <summary>
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="24" viewBox="0 0 16 24" fill="none">
+                <path d="M4.66667 24V20L0 15.3333V5.33333H2.66667V0H5.33333V5.33333H10.6667V0H13.3333V5.33333H16V15.3333L11.3333 20V24H4.66667Z" fill="#5A596B"/>
+              </svg>
+              Ask about your utilities
+            </summary>
+            <div class="accordion-body">
+              <p>Local officials should tell you when it’s safe to turn on your water, gas, and electricity. If the fire department has them shut off, it’s unsafe to turn them on yourself.</p>
+            </div>
+          </details>
+        </cagov-accordion>
+      </div>
+
+      <h2 class="m-b-md">Safety</h2>
+      <div class="recovery-card-group recovery-card-group-safety">
+        <div class="recovery-card">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="35" viewBox="0 0 28 35" fill="none">
+            <path d="M0 29.75V26.25H3.5V14C3.5 11.5792 4.22917 9.42812 5.6875 7.54688C7.14583 5.66563 9.04167 4.43333 11.375 3.85V0H16.625V3.85C18.9583 4.43333 20.8542 5.66563 22.3125 7.54688C23.7708 9.42812 24.5 11.5792 24.5 14V26.25H28V29.75H0ZM14 35C13.0375 35 12.2135 34.6573 11.5281 33.9719C10.8427 33.2865 10.5 32.4625 10.5 31.5H17.5C17.5 32.4625 17.1573 33.2865 16.4719 33.9719C15.7865 34.6573 14.9625 35 14 35ZM12.25 19.25H15.75V10.5H12.25V19.25ZM14 24.5C14.4958 24.5 14.9115 24.3323 15.2469 23.9969C15.5823 23.6615 15.75 23.2458 15.75 22.75C15.75 22.2542 15.5823 21.8385 15.2469 21.5031C14.9115 21.1677 14.4958 21 14 21C13.5042 21 13.0885 21.1677 12.7531 21.5031C12.4177 21.8385 12.25 22.2542 12.25 22.75C12.25 23.2458 12.4177 23.6615 12.7531 23.9969C13.0885 24.3323 13.5042 24.5 14 24.5Z" fill="#5A596B"/>
+          </svg>
+          <h3>Alerts</h3>
+          <ul>
+            <li><a href="https://www.fire.ca.gov/incidents">See where fires are</a></li>
+            <li><a href="https://www.listoscalifornia.org/alerts/">Sign up for emergency alerts</a></li>
+            <li><a href="https://earthquake.ca.gov/">Get earthquake warnings</a></li>
+            <li><a href="https://quickmap.dot.ca.gov/">See road closures</a></li>
+          </ul>
+        </div>
+        <div class="recovery-card">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="30" height="28" viewBox="0 0 30 28" fill="none">
+            <path d="M4.5 21.5H12V18.5H4.5V21.5ZM18.825 18.5L26.25 11.075L24.1125 8.9375L18.825 14.2625L16.6875 12.125L14.5875 14.2625L18.825 18.5ZM4.5 15.5H12V12.5H4.5V15.5ZM4.5 9.5H12V6.5H4.5V9.5ZM0 27.5V0.5H30V27.5H0Z" fill="#5A596B"/>
+          </svg>
+          <h3>Readiness</h3>
+          <ul>
+            <li><a href="https://readyforwildfire.org/prepare-for-wildfire/go-evacuation-guide/">How to evacuate safely</a></li>
+            <li><a href="https://www.earthquakeauthority.com/prepare-your-house-earthquake-risk">Prepare your home for an earthquake</a></li>
+          </ul>
+        </div>  
+      </div>
+
+      <h2 class="m-b-md">Food & shelter</h2>
+      <div class="recovery-card-group recovery-card-group-food-shelter">
+        <div class="recovery-card">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="32" viewBox="0 0 28 32" fill="none">
+            <path d="M14 0L0 10.6667V32H28V10.6667L14 0ZM14.875 16.8889C14.875 18.3644 13.7025 19.5556 12.25 19.5556V26.6667H10.5V19.5556C9.0475 19.5556 7.875 18.3644 7.875 16.8889V11.5556H9.625V16.8889H10.5V11.5556H12.25V16.8889H13.125V11.5556H14.875V16.8889ZM19.25 26.6667H17.5V20.4444H15.75V15.1111C15.75 13.1556 17.325 11.5556 19.25 11.5556V26.6667Z" fill="#5A596B"/>
+          </svg>
+          <h3>Food</h3>
+          <ul>
+            <li><a href="https://cdss.ca.gov/food-banks">Find a food bank</a></li>
+            <li><a href="https://benefitscal.com/">Apply for food stamps</a></li>
+            <li><a href="https://www.cdph.ca.gov/Programs/CFH/DWICSN/Pages/Program-Landing1.aspx">Food for families (WIC)</a></li>
+            <li><a href="https://www.cde.ca.gov/re/mo/cameals.asp">Meals for Kids app</a></li>
+            <li><a href="https://aging.ca.gov/">Food for seniors</a></li>
+          </ul>
+        </div>
+        <div class="recovery-card">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="32" viewBox="0 0 28 32" fill="none">
+            <path d="M14 0L0 10.6667V32H28V10.6667L14 0ZM10.0625 16.8889C11.27 16.8889 12.25 17.8844 12.25 19.1111C12.25 20.3378 11.27 21.3333 10.0625 21.3333C8.855 21.3333 7.875 20.3378 7.875 19.1111C7.875 17.8844 8.855 16.8889 10.0625 16.8889ZM22.75 26.6667H21V24H7V26.6667H5.25V14.2222H7V22.2222H13.125V16H19.25C21.175 16 22.75 17.6 22.75 19.5556V26.6667Z" fill="#5A596B"/>
+          </svg>
+          <h3>Shelter</h3>
+          <ul>
+            <li><a href="https://disasterassistance.gov/">Temporary housing</a></li>
+            <li><a href="https://www.calhfa.ca.gov/community/nms/index.htm">Housing counseling</a></li>
+            <li><a href="https://www.ccld.dss.ca.gov/carefacilitysearch/">Find child care</a></li>
+          </ul>
+        </div>  
+      </div>
+
+      <h2 class="m-b-md">Health</h2>
+      <div class="recovery-card-group recovery-card-group-health">
+        <div class="recovery-card">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="35" viewBox="0 0 28 35" fill="none">
+            <path d="M14 24.5C16.975 21.8167 18.8854 19.9281 19.7312 18.8344C20.5771 17.7406 21 16.6542 21 15.575C21 14.525 20.6208 13.6208 19.8625 12.8625C19.1042 12.1042 18.2 11.725 17.15 11.725C16.5375 11.725 15.9469 11.849 15.3781 12.0969C14.8094 12.3448 14.35 12.6875 14 13.125C13.65 12.6875 13.1979 12.3448 12.6437 12.0969C12.0896 11.849 11.4917 11.725 10.85 11.725C9.8 11.725 8.89583 12.1042 8.1375 12.8625C7.37917 13.6208 7 14.525 7 15.575C7 16.1292 7.07292 16.6396 7.21875 17.1062C7.36458 17.5729 7.68542 18.1198 8.18125 18.7469C8.67708 19.374 9.38437 20.1396 10.3031 21.0437C11.2219 21.9479 12.4542 23.1 14 24.5ZM14 35C9.94583 33.9792 6.59896 31.6531 3.95937 28.0219C1.31979 24.3906 0 20.3583 0 15.925V5.25L14 0L28 5.25V15.925C28 20.3583 26.6802 24.3906 24.0406 28.0219C21.401 31.6531 18.0542 33.9792 14 35Z" fill="#5A596B"/>
+          </svg>
+          <h3>Benefits</h3>
+          <ul>
+            <li><a href="https://aspr.hhs.gov/EPAP/Pages/epap-for-patients.aspx">Replace medications</a></li>
+            <li><a href="https://edd.ca.gov/en/disability/disability_insurance/">File for disability benefits</a></li>
+            <li><a href="https://www.dir.ca.gov/dlse/California-Paid-Sick-Leave.html">Paid sick leave</a></li>
+            <li><a href="https://edd.ca.gov/en/disability/paid-family-leave/">Paid family leave</a></li>
+          </ul>
+        </div>
+        <div class="recovery-card">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="36" viewBox="0 0 28 36" fill="none">
+            <path d="M14 0.5L0 5.75V16.4075C0 25.245 5.9675 33.4875 14 35.5C22.0325 33.4875 28 25.245 28 16.4075V5.75L14 0.5ZM12.145 24.195L5.95 18L8.4175 15.5325L12.1275 19.2425L19.5475 11.8225L22.015 14.29L12.145 24.195Z" fill="#5A596B"/>
+          </svg>
+          <h3>Insurance</h3>
+          <ul>
+            <li><a href="https://www.coveredca.com/apply/">Apply for medical insurance</a></li>
+            <li><a href="https://www.dhcs.ca.gov/Get-Medi-Cal/Pages/default.aspx">Apply for Medi-Cal</a></li>
+          </ul>
+        </div>  
+      </div>
+
+      <h2 class="m-b-md">Replacing documents</h2>
+      <div class="recovery-card-group recovery-card-group-documents">
+        <div class="recovery-card">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="29" height="30" viewBox="0 0 29 30" fill="none">
+            <path d="M25.947 7.79246H18.7395V3.46796C18.7395 1.88231 17.4422 0.584961 15.8565 0.584961H12.9735C11.3878 0.584961 10.0905 1.88231 10.0905 3.46796V7.79246H2.883C1.29735 7.79246 0 9.08981 0 10.6755V26.532C0 28.1176 1.29735 29.415 2.883 29.415H25.947C27.5326 29.415 28.83 28.1176 28.83 26.532V10.6755C28.83 9.08981 27.5326 7.79246 25.947 7.79246ZM10.0905 15C11.2869 15 12.2527 15.9658 12.2527 17.1622C12.2527 18.3587 11.2869 19.3245 10.0905 19.3245C8.89405 19.3245 7.92825 18.3587 7.92825 17.1622C7.92825 15.9658 8.89405 15 10.0905 15ZM14.415 23.649H5.766V22.5678C5.766 21.1263 8.649 20.4056 10.0905 20.4056C11.532 20.4056 14.415 21.1263 14.415 22.5678V23.649ZM15.8565 10.6755H12.9735V3.46796H15.8565V10.6755ZM23.064 21.4867H17.298V19.3245H23.064V21.4867ZM23.064 17.1622H17.298V15H23.064V17.1622Z" fill="#5A596B"/>
+          </svg>
+          <h3>IDs</h3>
+          <ul>
+            <li><a href="https://www.dmv.ca.gov/portal/online-change-of-address-coa-system/">Change your address with the DMV</a></li>
+            <li><a href="https://www.dmv.ca.gov/portal/driver-licenses-identification-cards/replace-your-driver-license-or-identification-dl-id-card/online-duplicate-driver-license-request/">Replace your driver's license</a></li>
+            <li><a href="https://www.ssa.gov/number-card/replace-card">Replace a Social Security card</a></li>
+            <li><a href="https://travel.state.gov/content/travel/en/passports/have-passport.html">Replace a US passport</a></li>
+            <li><a href="https://idco.dmdc.osd.mil/idco/">Replace a military ID</a></li>
+            <li><a href="https://www.uscis.gov/n-565">Replace naturalization or citizenship documents</a></li>
+            <li><a href="https://www.uscis.gov/green-card/after-we-grant-your-green-card/replace-your-green-card">Replace a Green Card</a></li>
+            <li><a href="https://www.dmv.ca.gov/portal/customer-service/request-vehicle-or-driver-records/online-vehicle-record-request/">Replace a vehicle registration</a></li>
+          </ul>
+        </div>
+        <div class="recovery-card">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30" fill="none">
+            <path d="M30 15L26.6727 11.1471L27.1364 6.05143L22.2136 4.91905L19.6364 0.5L15 2.51619L10.3636 0.5L7.78636 4.90524L2.86364 6.02381L3.32727 11.1333L0 15L3.32727 18.8529L2.86364 23.9624L7.78636 25.0948L10.3636 29.5L15 27.47L19.6364 29.4862L22.2136 25.081L27.1364 23.9486L26.6727 18.8529L30 15ZM12.3955 21.5181L7.21364 16.2567L9.23182 14.2129L12.3955 17.4305L20.3727 9.32429L22.3909 11.3681L12.3955 21.5181Z" fill="#5A596B"/>
+          </svg>
+          <h3>Certificates</h3>
+          <ul>
+            <li><a href="https://www.cdph.ca.gov/Programs/CHSI/Pages/Vital-Records-Obtaining-Certified-Copies-of-Birth-Records.aspx">Replace a CA birth certificate</a></li>
+            <li><a href="https://www.cdph.ca.gov/Programs/CHSI/Pages/Vital-Records-Obtaining-Certified-Copies-of-Marriage-Records.aspx">Replace a CA marriage certificate</a></li>
+            <li><a href="https://www.cdph.ca.gov/Programs/CHSI/Pages/Vital-Records-Obtaining-Certified-Copies-of-Death-Records.aspx">Replace a CA death certificate</a></li>
+            <li><a href="https://www.cdc.gov/nchs/w2w/index.htm">Replace birth, marriage, or death certificates from outside CA</a></li>
+          </ul>
+        </div>  
+      </div>
+
+      <h2 class="m-b-md">Financial help</h2>
+      <div class="recovery-card-group recovery-card-group-financial">
+        <div class="recovery-card">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="35" viewBox="0 0 28 35" fill="none">
+            <path d="M17.5 0H3.5C1.575 0 0.0175004 1.575 0.0175004 3.5L0 31.5C0 33.425 1.5575 35 3.4825 35H24.5C26.425 35 28 33.425 28 31.5V10.5L17.5 0ZM19.25 17.5H12.25V19.25H17.5C18.4625 19.25 19.25 20.0375 19.25 21V26.25C19.25 27.2125 18.4625 28 17.5 28H15.75V29.75H12.25V28H8.75V24.5H15.75V22.75H10.5C9.5375 22.75 8.75 21.9625 8.75 21V15.75C8.75 14.7875 9.5375 14 10.5 14H12.25V12.25H15.75V14H19.25V17.5ZM15.75 10.5V2.625L23.625 10.5H15.75Z" fill="#5A596B"/>
+          </svg>
+          <h3>Insurance & loans</h3>
+          <ul>
+            <li><a href="https://www.insurance.ca.gov/01-consumers/140-catastrophes/">Help with your insurance claim</a></li>
+            <li><a href="https://www.insurance.ca.gov/01-consumers/101-help/index.cfm">File a homeowner's insurance complaint</a></li>
+            <li><a href="http://lending.sba.gov/">Disaster loans</a></li>
+            <li><a href="https://www.calassistmortgagefund.org/">Mortgage protections</a></li>
+            <li><a href="https://dfpi.ca.gov/lafires/federal-and-private-student-loan-relief-faq/">Student loan protections</a></li>
+          </ul>
+        </div>
+        <div class="recovery-card">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="26" viewBox="0 0 28 26" fill="none">
+            <path d="M11.2 18.5999V17.1999H1.414L1.4 22.7999C1.4 24.3539 2.646 25.5999 4.2 25.5999H23.8C25.354 25.5999 26.6 24.3539 26.6 22.7999V17.1999H16.8V18.5999H11.2ZM25.2 5.9999H19.586V3.1999L16.786 0.399902H11.186L8.386 3.1999V5.9999H2.8C1.26 5.9999 0 7.2599 0 8.7999V12.9999C0 14.5539 1.246 15.7999 2.8 15.7999H11.2V12.9999H16.8V15.7999H25.2C26.74 15.7999 28 14.5399 28 12.9999V8.7999C28 7.2599 26.74 5.9999 25.2 5.9999ZM16.8 5.9999H11.2V3.1999H16.8V5.9999Z" fill="#5A596B"/>
+          </svg>
+          <h3>Employment</h3>
+          <ul>
+            <li><a href="https://edd.ca.gov/en/unemployment/">File for unemployment</a></li>
+            <li><a href="https://edd.ca.gov/en/jobs/">Find a job</a></li>
+            <li><a href="https://calcareers.ca.gov/">Find a job with CA state government</a></li>
+            <li><a href="https://edd.ca.gov/en/jobs_and_training/">Find job training</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/pages/topics/single.html
+++ b/pages/topics/single.html
@@ -37,7 +37,12 @@ eleventyComputed:
               Topics
             </a>
           </li>
-          {%- for link in topics | sortBy("featureOrder") %} {%- set href =
+
+          {# Hack an additional item into the sidebar nav. #}
+          {%- set disasterRecoveryObj = { featureOrder: 8.5, slug: "disaster-recovery", name: "Disaster recovery" } -%}
+          {%- set modifiedTopics = topics.concat(disasterRecoveryObj) -%}
+
+          {%- for link in modifiedTopics | sortBy("featureOrder") %} {%- set href =
           "/topics/"+link.slug+"/" -%} {%- set active = href === page.url -%}
           <li>
             <a


### PR DESCRIPTION
Adds the new Disaster Recovery page.

There are a couple things about this page that are weird, so I'll list them out below. 

* Our stakeholders want this page to live under the Topics section. However, the design is clearly different from every other templated page in that section. For now, I just added the unique `disaster-recovery.html` file into the `topics` folder. 
* I'm not sure how the `topics.json` data file is managed. So instead, I cheated in the Nunjucks templates by adding the Disaster Recovery sidebar item manually. "Dirty hack" is probably the most generous way to describe this. 

```
{# Hack an additional item into the sidebar nav. #}
{%- set disasterRecoveryObj = { featureOrder: 8.5, slug: "disaster-recovery", name: "Disaster recovery" } -%}
{%- set modifiedTopics = topics.concat(disasterRecoveryObj) -%}
 ```
 
I'm guessing there are better ways to manage this content that fit better with your data and flow. If so, no problem, happy to work through it. Just let me know how you'd prefer to approach this.