### PR TITLE
Fix mailto link on immigration page for immigrantintegration.initiatives@gobiz.ca.gov

### DIFF
--- a/pages/initiatives/immigration/index.html
+++ b/pages/initiatives/immigration/index.html
@@ -43,7 +43,7 @@ permalink: immigration/
           immigration rules affect Californians’ eligibility for public
           programs, you may reach out to the state’s Council on immigration
           issues at
-          <a href="./documents/fact-sheet-immigration-issues.pdf"
+          <a href="mailto:immigrantintegration.initiatives@gobiz.ca.gov"
             >immigrantintegration.initiatives@gobiz.ca.gov</a
           >.
         </p>


### PR DESCRIPTION
I had the wrong hyperlink for this email 
<img width="912" height="272" alt="{CC8B58A8-3EB0-4991-B3CE-DCE062EC49CE}" src="https://github.com/user-attachments/assets/026301f8-1a34-4bab-ad89-1b75f48fa0fd" />
